### PR TITLE
:bug: fix(alembic): `UnicodeDecodeError` when `list_templates`

### DIFF
--- a/nonebot_plugin_orm/migrate.py
+++ b/nonebot_plugin_orm/migrate.py
@@ -341,7 +341,7 @@ def list_templates(config: AlembicConfig) -> None:
 
     config.print_stdout("可用的模板：\n")
     for tempname in Path(config.get_template_directory()).iterdir():
-        with (tempname / "README").open() as readme:
+        with (tempname / "README").open(encoding="utf-8") as readme:
             synopsis = readme.readline().rstrip()
 
         config.print_stdout(f"{tempname.name} - {synopsis}")


### PR DESCRIPTION
This commit resolves the UnicodeDecodeError encountered when the
nonebot_plugin_orm's migrate.py script attempts to read a file with
a default 'gbk' encoding. The issue occurs specifically in the
list_templates function, where the script reads the 'readme' file.

The error is fixed by specifying UTF-8 as the encoding when opening
the file. This change ensures that the file is correctly read
regardless of the system's default encoding, preventing the
UnicodeDecodeError when dealing with files containing characters
not supported by the 'gbk' encoding.